### PR TITLE
fix getPageData for threads only having 1 page

### DIFF
--- a/src/background/requests/getPageData.ts
+++ b/src/background/requests/getPageData.ts
@@ -13,6 +13,8 @@ export async function getPageData(url: string) {
 	// Check page numbers
 	let largestPageNumber: number | undefined;
 	let activePageNumber: number | undefined;
+
+	// currently threads with only 1 page is not handled
 	pagination.each((_index, element) => {
 		const text = $(element).text();
 		const active = $(element).hasClass('active');
@@ -55,8 +57,8 @@ export async function getPageData(url: string) {
 
 	return {
 		title,
-		lastPage: largestPageNumber,
-		currentPage: activePageNumber,
+		lastPage: largestPageNumber || 1,
+		currentPage: activePageNumber || 1,
 		votes,
 	};
 }

--- a/src/content/thread.ts
+++ b/src/content/thread.ts
@@ -40,10 +40,7 @@ export async function getThreadData(threadId: string) {
 	let votes: Vote[] = [];
 
 	let loopIndex = 0;
-	// totalPages is from website pagination (25 posts)
-	// getPageData fetches 200 posts at a time
-	// so we don't need to fetch more than Math.ceil(totalPages / 8) times
-	while (totalPages == undefined || loopIndex < Math.ceil(totalPages)) {
+	while (totalPages == undefined || loopIndex < totalPages) {
 		const pageData = await getPageData({
 			threadId,
 			take: 200,

--- a/src/content/thread.ts
+++ b/src/content/thread.ts
@@ -40,7 +40,10 @@ export async function getThreadData(threadId: string) {
 	let votes: Vote[] = [];
 
 	let loopIndex = 0;
-	while (totalPages == undefined || loopIndex < totalPages) {
+	// totalPages is from website pagination (25 posts)
+	// getPageData fetches 200 posts at a time
+	// so we don't need to fetch more than Math.ceil(totalPages / 8) times
+	while (totalPages == undefined || loopIndex < Math.ceil(totalPages)) {
 		const pageData = await getPageData({
 			threadId,
 			take: 200,


### PR DESCRIPTION
Fixed getPageData unable to return the expected number of 'currentPage' and 'lastPage' if the game thread only has 1 page.

~~Fixed getThreadData while loop calling getPageData more times than necessary.~~